### PR TITLE
Fix sticky headers by scoping header styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,11 +39,11 @@
     .muted{color:var(--muted)}
 
     /* ===== Header / Nav ===== */
-    header{position:fixed;inset:0 0 auto 0;height:76px;display:flex;align-items:center;justify-content:center;z-index:1000}
+    #hdr{position:fixed;inset:0 0 auto 0;height:76px;display:flex;align-items:center;justify-content:center;z-index:1000}
     .nav{width:min(100%,var(--maxw));display:flex;align-items:center;justify-content:space-between;padding:0 var(--space)}
     .brand{text-decoration:none;color:var(--text);font-weight:800;letter-spacing:.6px}
     .bar{display:flex;gap:.25rem;align-items:center;border:1px solid rgba(255,255,255,.06);background:rgba(18,20,28,.45);backdrop-filter:blur(10px);-webkit-backdrop-filter:blur(10px);padding:.35rem .5rem;border-radius:999px;box-shadow:0 1px 0 rgba(255,255,255,.05) inset}
-    header.solid .bar{background:rgba(18,20,28,.75)}
+    #hdr.solid .bar{background:rgba(18,20,28,.75)}
     .lnk{position:relative;display:inline-block;padding:.55rem .8rem;color:var(--text)}
     .lnk::after{content:"";position:absolute;left:.7rem;right:.7rem;bottom:.25rem;height:2px;background:linear-gradient(90deg,var(--accent),var(--accent2));transform:scaleX(0);transform-origin:left;transition:transform .25s ease}
     .lnk:hover::after,.lnk.active::after{transform:scaleX(1)}


### PR DESCRIPTION
## Summary
- scope header styling to `#hdr` so only the site header is fixed
- keep card headers from sticking on scroll

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b87568b880832084794043b3142413