### PR TITLE
Normalize logos section styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,9 +74,35 @@
     .fx-reveal{transition-delay:var(--d,0s)}
 
     /* ===== Logos ===== */
-    .logos{margin-top:1.1rem;display:grid;grid-template-columns:repeat(4,minmax(120px,1fr));gap:12px}
-    .logo{height:54px;border:1px solid var(--border);border-radius:10px;background:linear-gradient(180deg,rgba(255,255,255,.04),rgba(255,255,255,.02));position:relative;overflow:hidden}
-    .logo img{width:100%;height:100%;object-fit:contain}
+    .logos{
+      margin-top:1.1rem;
+      display:grid;
+      grid-template-columns:repeat(4,minmax(120px,1fr));
+      gap:12px;
+      background:#fff;
+      padding:20px;
+      border-radius:var(--radius);
+    }
+    .logo{
+      height:80px;
+      border:1px solid var(--border);
+      border-radius:10px;
+      background:#fff;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:10px;
+    }
+    .logo img{
+      max-width:100%;
+      max-height:100%;
+      object-fit:contain;
+    }
+    .logo span{
+      color:#000;
+      font-weight:600;
+      text-align:center;
+    }
     .shimmer::before{content:"";position:absolute;inset:0;background:linear-gradient(110deg,transparent 0%,rgba(255,255,255,.06) 45%,transparent 60%);transform:translateX(-100%);animation:sh 3s infinite}
     @keyframes sh{to{transform:translateX(100%)}}
 
@@ -171,7 +197,7 @@
             <img src="https://sockatyes.co.uk/assets/logohorizontal.webp" alt="Sockatyes logo">
           </a>
           <a class="logo" href="https://nicomalgeri.github.io/parkerlloydgroup/" target="_blank" rel="noopener" aria-label="Parker Lloyd Group">
-            <img src="https://nicomalgeri.github.io/parkerlloydgroup/logo.png" alt="Parker Lloyd Group logo">
+            <span>Parker Lloyd Group</span>
           </a>
           <a class="logo" href="https://mecavalmecanizados.com/" target="_blank" rel="noopener" aria-label="Mecaval Mecanizados">
             <img src="https://mecavalmecanizados.com/wp-content/uploads/2025/04/cropped-Untitled-design-2-1-1.png" alt="Mecaval Mecanizados logo">


### PR DESCRIPTION
## Summary
- add white background and padding to logo grid for a cleaner strip
- ensure logos share consistent sizing and styling
- replace Parker Lloyd Group logo image with text

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/marketing-website/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68b87b3f469483208c1dc9598322a6dd